### PR TITLE
Add safebrowsing.apple

### DIFF
--- a/Rules/Services/Apple.list
+++ b/Rules/Services/Apple.list
@@ -64,6 +64,7 @@ host-suffix,push.apple.com,Apple
 
 # >> Other Service
 host,api.smoot.apple.cn,Proxy
+host-suffix,safebrowsing.apple,Apple
 
 # > Apple Music
 host,hls.itunes.apple.com,Apple Music

--- a/Rules/Services/Apple.list
+++ b/Rules/Services/Apple.list
@@ -64,7 +64,7 @@ host-suffix,push.apple.com,Apple
 
 # >> Other Service
 host,api.smoot.apple.cn,Proxy
-host-suffix,safebrowsing.apple,Apple
+host-suffix,safebrowsing.apple,Proxy
 
 # > Apple Music
 host,hls.itunes.apple.com,Apple Music


### PR DESCRIPTION
目前有观察到国内 doh 对 `*.safebrowsing.apple` 一系列域名会返回 NXDOMAIN，因此希望加入 Apple 的 Proxy list