### PR TITLE
🐞 尝试修复 Microsoft 规则中 Live 使用域名关键字容易误中的问题

### DIFF
--- a/Rules/Services/Microsoft.list
+++ b/Rules/Services/Microsoft.list
@@ -136,7 +136,8 @@ host-suffix,outlookgroups.ms,Microsoft
 host-suffix,outlookmobile.com,Microsoft
 
 # > Live
-host-keyword,live,Microsoft
+host-suffix,live.com,Microsoft
+host-suffix,live.net,Microsoft
 host-suffix,sclive.net,Microsoft
 host-suffix,windowslive.cn,Microsoft
 host-suffix,wlxrs.com,Microsoft


### PR DESCRIPTION
解决 #30 🐞 尝试修复 Microsoft 规则中 Live 使用域名关键字容易误中的问题
