### PR TITLE
为 Bilibili 新 CDN 域名设置规则

### DIFF
--- a/Rules/Media/DomesticMedia.list
+++ b/Rules/Media/DomesticMedia.list
@@ -5,6 +5,7 @@ host-suffix,biliapi.net,Bilibili
 host-suffix,bilibili.com,Bilibili
 host-suffix,bilibili.tv,Bilibili
 host-suffix,hdslb.com,Bilibili
+host-suffix,bilivideo.com,Bilibili
 # YYeTs
 user-agent,YYeTs*,DIRECT
 host-suffix,jstucdn.com,DIRECT


### PR DESCRIPTION
目前观察发现B站启用了 `bilivideo.com` 域名作为视频 CDN 域名使用。