### PR TITLE
#147-block-bilibili-pdcn

### DIFF
--- a/Rules/Media/Domestic/BiliBili.list
+++ b/Rules/Media/Domestic/BiliBili.list
@@ -91,3 +91,7 @@ ip-cidr,134.175.207.130/32,BiliBili
 ip-cidr,150.116.92.250/32,BiliBili
 ip-cidr,164.52.76.18/32,BiliBili
 ip-cidr,203.107.1.0/24,BiliBili
+
+# >> B站 PCDN 屏蔽
+host-suffix, v1d.szbdyd.com, reject
+host-suffix, mcdn.bilivideo.cn, reject


### PR DESCRIPTION
Fixes #147

Add rules to reject 'szbdyd.com' and 'mcdn.bilivideo.cn' domains to improve B station CDN performance.

* **Rules/Media/Domestic/BiliBili.list**
  * Add rule to reject 'v1d.szbdyd.com'
  * Add rule to reject 'mcdn.bilivideo.cn'

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sve1r/Rules-For-Quantumult-X/pull/148?shareId=c98913e2-29b3-4832-b290-bd927a5ceec7).